### PR TITLE
fix: parsing of path in widowns

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -66,6 +66,7 @@ Cypress.Commands.add('mockApi', (options = {}) => {
     // @ts-ignore
     .then((mocks: Mocks[]) => {
       mocks.forEach((mock) => {
+        mock.url = mock.url.split("\\").join("/");
         cy.route(mock).as(mock.alias);
       });
     });


### PR DESCRIPTION
For Windows path are separated with \, and for Unix based os they are separated with /.
So when parsing the fixtures in windows the url come up with \, which will lead to request not being mocked.

This fix will not break in Linux.
This PR solves #4 